### PR TITLE
Implemented value_from_dict function to support leftout days

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import django
+import datetime
+
 if django.VERSION >= (1,9):
     from django.forms.utils import flatatt
 else:    
@@ -138,3 +140,7 @@ class DateTimePicker(DateTimeInput):
         else:
             js = ''
         return mark_safe(force_text(html + js))
+
+    def value_from_datadict(self,data,files,name):
+        return datetime.datetime.strptime(data.get(name),self.format)
+        


### PR DESCRIPTION
When a format without days is specified the widget now can be used directly with a django DateField. By implementing a value_from_dict function it generates a valid datetime string by the format specified.